### PR TITLE
Provide command-line scripts for shrike.build

### DIFF
--- a/docs/build/build-for-sign-and-register.md
+++ b/docs/build/build-for-sign-and-register.md
@@ -51,11 +51,11 @@ use_build_number: True
 
 To consume this configuration file, we should pass its path to the command line, that is
 ```ps
-python -m shrike.build.commands.prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE
+shrike-prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE
 ```
 If we want to override the values of `activation_method` and `fail_if_version_exists` at runtime, we should append them to the command line:
 ```ps
-python -m shrike.build.commands.prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE --activation-method smart --fail-if-version-exists
+shrike-prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE --activation-method smart --fail-if-version-exists
 ```
 
 
@@ -121,7 +121,7 @@ A sample YAML script of preparation step
     scriptLocation: inlineScript
     scriptType: pscore
     inlineScript: |
-      python -m shrike.build.commands.prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE
+      shrike-prepare --configuration-file PATH/TO/MY_CONFIGURATION_FILE
     workingDirectory: $(MY_WORK_DIRECTORY)
 ```
 
@@ -216,7 +216,7 @@ The last step is to register all signed components in your Azure ML workspaces. 
 Azure CLI command `az ml component --create --file {component}`. The Python call is
 
 ```python
-python -m shrike.build.commands.register --configuration-file path/to/config
+shrike-register --configuration-file path/to/config
 ```
 In this step, the `register` class can detect signed and built components.
 There are five configuration parameters related to the registration step: `--compliant-branch`, `--source-branch`, `--fail-if-version-exists`, `--use-build-number`, and `--all-component-version`. They should be customized in the `configure-file` according to your specific use case.
@@ -235,7 +235,7 @@ A sample YAML task for registration is
     scriptLocation: inlineScript
     scriptType: pscore
     inlineScript: |
-      python -m shrike.build.commands.register --configuration-file PATH/TO/MY_CONFIGURATION_FILE
+      shrike-register --configuration-file PATH/TO/MY_CONFIGURATION_FILE
     workingDirectory: $(MY_WORK_DIRECTORY)
 ```
 
@@ -326,7 +326,7 @@ parameters:
 Inline script portion of your "prepare" and "register" steps (you will need to customize the configuration file name and glob to your repository).
 
 ```bash
-python -m shrike.build.commands.register --configuration-file sign-register-config-dev.yaml --component-specification-glob src/steps/${{ parameters.aml_component }}/component_spec.yaml
+shrike-register --configuration-file sign-register-config-dev.yaml --component-specification-glob src/steps/${{ parameters.aml_component }}/component_spec.yaml
 ```
 
 Then, members of your team can manually trigger builds via the Azure DevOps UI, setting the `aml_component` parameter to the name of the component they want to code-sign and register.

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,12 @@ setup(
     packages=find_packages(include=["shrike*"]),
     include_package_data=True,
     install_requires=required_logging,
+    entry_points={
+        "console_scripts": [
+            "shrike-prepare=shrike.build.commands.prepare:main",
+            "shrike-register=shrike.build.commands.register:main",
+        ],
+    },
     extras_require={
         "pipeline": required_pipeline,
         "build": required_build,

--- a/shrike/__init__.py
+++ b/shrike/__init__.py
@@ -6,4 +6,4 @@ Python utilities to aid "compliant experimentation" - training
 machine learning models without seeing the training data.
 """
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"

--- a/shrike/build/commands/prepare.py
+++ b/shrike/build/commands/prepare.py
@@ -866,6 +866,9 @@ CATATTR1=0x00010001:OSAttr:2:6.2
                     validation_success = False
         return validation_success
 
+def main():
+    """The main function for preparing components"""
+    Prepare().run()
 
 if __name__ == "__main__":
-    Prepare().run()
+    main()

--- a/shrike/build/commands/register.py
+++ b/shrike/build/commands/register.py
@@ -169,6 +169,9 @@ class Register(Command):
                 log.info("List of components in workspace after current registration.")
                 self.list_registered_component()
 
+def main():
+    """The main function for registering components"""
+    Register().run()
 
 if __name__ == "__main__":
-    Register().run()
+    main()


### PR DESCRIPTION
Currently, users of the "build" functionality this library provides must write somewhat verbose scripts to consume it, e.g.
```bash
python -m shrike.build.prepare --configuration-file path/to/config.yaml
```
This is both a bit annoying to read, and a leaky abstraction (it exposes Python namespaces to the command line).

In this PR, we leveraged [python-setuptools' command line scripts](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html) to expose "raw" commands like:
```
shrike-prepare --configuration-file path/to/config.yaml
shrike-register --configuration-file path/to/config.yaml
```
