### PR TITLE
Run component governance in both Linux and Windows

### DIFF
--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -3,8 +3,9 @@ trigger:
   branches:
     include:
     - main
-  pr:
-  - main
+
+pr:
+- main
 
 schedules:
 - cron: 0 12 * * 0
@@ -26,7 +27,7 @@ parameters:
 
 jobs:
 
-- ${{ each image in parameters.images }}
+- ${{ each image in parameters.images }}:
 
   - job: ${{ image }}
 

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -32,7 +32,7 @@ jobs:
   - job: ${{ os }}
 
     pool:
-      vmImage: ${{ image }}-latest
+      vmImage: ${{ os }}-latest
 
     steps:
 

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -43,6 +43,15 @@ jobs:
         Get-ChildItem requirements/*.txt | Get-Content | Out-File requirements.txt
       displayName: Coalesce requirements files
 
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.8
+
+    # CG detects transitive dependencies by seeing what is pip installed.
+    - pwsh: |
+        pip install -r requirements.txt
+      displayName: pip install
+
     - task: ComponentGovernanceComponentDetection@0
       inputs:
         verbosity: Verbose

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -3,6 +3,8 @@ trigger:
   branches:
     include:
     - main
+  pr:
+  - main
 
 schedules:
 - cron: 0 12 * * 0
@@ -12,30 +14,42 @@ schedules:
     - main
   always: true
 
+parameters:
 
-pool:
-  vmImage: ubuntu-latest
+- name: images
+  type: object
+    values:
+    - ubuntu-latest
+    # Dependencies and the corresponding CG alerts may be different
+    # in each operating system.
+    - windows-latest
 
-steps:
+jobs:
 
-- checkout: self
-  clean: true
+- ${{ each image in parameters.images }}
 
-- bash: |
-    cat requirements/requirements-logging.txt >> requirements.txt
-    cat requirements/requirements-pipeline.txt >> requirements.txt
-    cat requirements/requirements-build.txt >> requirements.txt
-    cat requirements/requirements-dev.txt >> requirements.txt  
-  displayName: Pool Requirement Files
+  - job: ${{ image }}
 
-- task: ComponentGovernanceComponentDetection@0
-  inputs:
-    verbosity: Verbose
-    alertWarningLevel: Medium
-    failOnAlert: true
-  displayName: Component Governance ( aka.ms/cgdocs )
+    pool:
+      vmImage: ${{ image }}
 
-- task: notice@0
-  displayName: generate NOTICE
-  inputs:
-    outputformat: text
+    steps:
+
+    - checkout: self
+      clean: true
+
+    - pwsh: |
+        Get-ChildItem requirements/*.txt | Get-Content | Out-File requirements.txt
+      displayName: Coalesce requirements files
+
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        verbosity: Verbose
+        alertWarningLevel: Medium
+        failOnAlert: true
+      displayName: Component Governance ( aka.ms/cgdocs )
+
+  - task: notice@0
+    displayName: generate NOTICE
+    inputs:
+      outputformat: text

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -18,11 +18,11 @@ parameters:
 
 - name: images
   type: object
-    values:
-    - ubuntu-latest
-    # Dependencies and the corresponding CG alerts may be different
-    # in each operating system.
-    - windows-latest
+  default:
+  - ubuntu-latest
+  # Dependencies and the corresponding CG alerts may be different
+  # in each operating system.
+  - windows-latest
 
 jobs:
 

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -50,7 +50,7 @@ jobs:
         failOnAlert: true
       displayName: Component Governance ( aka.ms/cgdocs )
 
-  - task: notice@0
-    displayName: generate NOTICE
-    inputs:
-      outputformat: text
+    - task: notice@0
+      displayName: generate NOTICE
+      inputs:
+        outputformat: text

--- a/.azure-pipelines/cg.yml
+++ b/.azure-pipelines/cg.yml
@@ -17,22 +17,22 @@ schedules:
 
 parameters:
 
-- name: images
+- name: operating_systems
   type: object
   default:
-  - ubuntu-latest
+  - ubuntu
   # Dependencies and the corresponding CG alerts may be different
   # in each operating system.
-  - windows-latest
+  - windows
 
 jobs:
 
-- ${{ each image in parameters.images }}:
+- ${{ each os in parameters.operating_systems }}:
 
-  - job: ${{ image }}
+  - job: ${{ os }}
 
     pool:
-      vmImage: ${{ image }}
+      vmImage: ${{ image }}-latest
 
     steps:
 


### PR DESCRIPTION
Component Governance will raise different alerts in Linux vs. Windows. This PR runs CG in both and on PRs. For context, see:

> [Compliant AML: Component governance alerts due to shrike package](https://stackoverflow.microsoft.com/q/276049)

## Changes

- Run CG in both Linux and Windows
- Run CG against PRs.

## To-do

- [ ] Fix any CG alerts raised in Windows.
- [ ] Version bump.
