### PR TITLE
Adding experiment description as an optional config

### DIFF
--- a/docs/pipeline/configure-aml-pipeline.md
+++ b/docs/pipeline/configure-aml-pipeline.md
@@ -88,6 +88,7 @@ In this section, you configure the parameters controlling how to run your experi
 # run parameters are command line arguments for running your experiment
 run: # params for running pipeline
   experiment_name: "demo_graph_eyeson" # IMPORTANT
+  experiment_description: "Demo for eyeson graph"
   regenerate_outputs: false
   continue_on_failure: false
   verbose: false

--- a/examples/pipelines/config/experiments/demo_component_with_parameter.yaml
+++ b/examples/pipelines/config/experiments/demo_component_with_parameter.yaml
@@ -14,6 +14,7 @@ defaults:
 # run parameters are command line arguments for running your experiment
 run: # params for running pipeline
   experiment_name: "demo_component_with_parameter" # IMPORTANT
+  experiment_description: "The demo of a component that operates on a parameter"
   regenerate_outputs: false
   continue_on_failure: false
   verbose: false

--- a/examples/pipelines/config/experiments/demo_count_rows_and_log.yaml
+++ b/examples/pipelines/config/experiments/demo_count_rows_and_log.yaml
@@ -14,6 +14,7 @@ defaults:
 # run parameters are command line arguments for running your experiment
 run: # params for running pipeline
   experiment_name: "demo_count_rows_and_log" # IMPORTANT
+  experiment_description: "Demo of a component that reads a dataset and counts the rows."
   regenerate_outputs: false
   continue_on_failure: false
   verbose: false

--- a/shrike/pipeline/pipeline_config.py
+++ b/shrike/pipeline/pipeline_config.py
@@ -26,6 +26,7 @@ class pipeline_cli_config:  # pylint: disable=invalid-name
     silent: bool = False
     wait: bool = False
     experiment_name: str = MISSING
+    experiment_description: Optional[str] = None
     pipeline_run_id: str = MISSING
     tags: Optional[Any] = None
     config_dir: Optional[str] = None

--- a/shrike/pipeline/pipeline_helper.py
+++ b/shrike/pipeline/pipeline_helper.py
@@ -1391,6 +1391,7 @@ class AMLPipelineHelper:
             # is different from "azureml.pipeline.core.PipelineRun"
             pipeline_run = pipeline.submit(
                 experiment_name=self.config.run.experiment_name,
+                description=self.config.run.experiment_description,
                 tags=pipeline_tags,
                 default_compute_target=self.config.compute.default_compute_target,
                 regenerate_outputs=self.config.run.regenerate_outputs,


### PR DESCRIPTION
Adding the capability to optionally add at a config level
```yaml
# run parameters are command line arguments for running your experiment
run: # params for running pipeline
  experiment_name: "demo_graph_eyeson" # IMPORTANT
  experiment_description: "Demo for eyeson graph"  <====
  regenerate_outputs: false
  continue_on_failure: false
  verbose: false
  submit: false
  resume: false
  canary: false
  silent: false
  wait: false
```

Modified some examples so as to showcase how it could be used.
